### PR TITLE
chore: fix pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-json
@@ -12,8 +12,9 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
       - id: check-shebang-scripts-are-executable
+
   - repo: https://github.com/hadolint/hadolint
-    rev: b3555ba9c2bfd9401e79f2f0da68dd1ae38e10c7 # v2.12.0
+    rev: v2.14.0
     hooks:
       - id: hadolint-docker
         name: Lint Dockerfiles
@@ -21,22 +22,16 @@ repos:
         language: docker_image
         types: ["dockerfile"]
         entry: ghcr.io/hadolint/hadolint hadolint
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
+
+  - repo: https://github.com/tekwizely/pre-commit-golang
+    rev: v1.0.0-rc.4
     hooks:
       - id: go-mod-tidy
       - id: go-fmt
-      - id: go-vet
-      - id: golangci-lint
-      - id: go-build
-  - repo: local
-    hooks:
-      - id: run-go-tests
-        name: Run Go Tests
-        entry: make test
-        language: system
-        types: [go]
-        verbose: false
+      - id: golangci-lint-mod
+        args: [--fix]
+      - id: go-test-mod
+
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0
     hooks:


### PR DESCRIPTION
Update pre-commit hooks: migrate from unmaintained dnephin/pre-commit-golang to tekwizely, upgrade stale hook revisions, and fix missing/stale hooks.